### PR TITLE
migrate to new tags with cluster name and role in tag value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ build:
 
 .PHONY: docker-image
 docker-image:
-	@if [[ ! -f ${BINARY_PATH}/rel/cmi-plugin ]]; then echo "No binary found. Please run 'make build'"; false; fi
+	@if [[ ! -f ${BINARY_PATH}/rel/machine-controller ]]; then echo "No binary found. Please run 'make build'"; false; fi
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) .
 
 .PHONY: docker-push

--- a/pkg/vsphere/apis/provider_spec.go
+++ b/pkg/vsphere/apis/provider_spec.go
@@ -14,6 +14,17 @@ limitations under the License.
 
 package api
 
+const (
+	// TagClusterPrefix is the old tag prefix for tagging the cluster name
+	TagClusterPrefix = "kubernetes.io/cluster/"
+	// TagNodeRolePrefix is the old tag prefix for tagging the node role
+	TagNodeRolePrefix = "kubernetes.io/role/"
+	// TagMCMClusterName is the tag key for tagging a VM with the cluster name
+	TagMCMClusterName = "mcm.gardener.cloud/cluster"
+	// TagMCMRole is the tag key for tagging a VM with its role (e.g 'node')
+	TagMCMRole = "mcm.gardener.cloud/role"
+)
+
 // VsphereProviderSpec contains the fields of
 // provider spec that the plugin expects
 type VsphereProviderSpec struct {

--- a/pkg/vsphere/apis/tags/tagutils.go
+++ b/pkg/vsphere/apis/tags/tagutils.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package tags
+
+import (
+	"fmt"
+	"strings"
+
+	api "github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis"
+)
+
+// RelevantTags contains tags keys and values for cluster name and role
+type RelevantTags struct {
+	clusterNameKey string
+	clusterName    string
+	nodeRoleKey    string
+	nodeRole       string
+}
+
+// NewRelevantTags creates RelevantTags from given tag map.
+// Returns nil if no complete set of tags provided.
+func NewRelevantTags(tags map[string]string) (*RelevantTags, []error) {
+	var clusterNameKey, clusterName, nodeRoleKey, nodeRole string
+	for key, value := range tags {
+		if strings.HasPrefix(key, api.TagClusterPrefix) {
+			clusterNameKey = key
+			clusterName = clusterNameKey[len(api.TagClusterPrefix):]
+		} else if strings.HasPrefix(key, api.TagNodeRolePrefix) {
+			nodeRoleKey = key
+			nodeRole = nodeRoleKey[len(api.TagNodeRolePrefix):]
+		} else if key == api.TagMCMClusterName {
+			clusterNameKey = api.TagClusterPrefix + value
+			clusterName = value
+		} else if key == api.TagMCMRole {
+			nodeRoleKey = api.TagNodeRolePrefix + value
+			nodeRole = value
+		}
+	}
+
+	var allErrs []error
+	if clusterNameKey == "" {
+		allErrs = append(allErrs, fmt.Errorf("tag required of the form '%s=****' or '%s****=1'", api.TagMCMClusterName, api.TagClusterPrefix))
+	}
+	if nodeRoleKey == "" {
+		allErrs = append(allErrs, fmt.Errorf("tag required of the form '%s=****' or '%s****=1'", api.TagMCMRole, api.TagNodeRolePrefix))
+	}
+	if allErrs != nil {
+		return nil, allErrs
+	}
+
+	return &RelevantTags{
+		clusterNameKey: clusterNameKey,
+		clusterName:    clusterName,
+		nodeRoleKey:    nodeRoleKey,
+		nodeRole:       nodeRole,
+	}, nil
+}
+
+// Matches checks if given tags matches cluster name and role
+func (t *RelevantTags) Matches(tags map[string]string) bool {
+	matchedCluster := false
+	matchedRole := false
+	for key, value := range tags {
+		switch key {
+		case t.clusterNameKey:
+			matchedCluster = true
+		case t.nodeRoleKey:
+			matchedRole = true
+		case api.TagMCMClusterName:
+			if value == t.clusterName {
+				matchedCluster = true
+			}
+		case api.TagMCMRole:
+			if value == t.nodeRole {
+				matchedRole = true
+			}
+		}
+	}
+	return matchedCluster && matchedRole
+}

--- a/pkg/vsphere/apis/tags/tagutils_test.go
+++ b/pkg/vsphere/apis/tags/tagutils_test.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package tags
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	api "github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis"
+)
+
+const (
+	cluster1 = "cluster"
+	cluster2 = "cluster2"
+	role     = "node"
+)
+
+var (
+	oldSpecTags = map[string]string{
+		api.TagClusterPrefix + cluster1: "1",
+		api.TagNodeRolePrefix + role:    "1",
+	}
+
+	oldSpecTags2 = map[string]string{
+		api.TagClusterPrefix + cluster2: "1",
+		api.TagNodeRolePrefix + role:    "1",
+	}
+
+	newSpecTags = map[string]string{
+		api.TagMCMClusterName: cluster1,
+		api.TagMCMRole:        role,
+	}
+
+	newSpecTags2 = map[string]string{
+		api.TagMCMClusterName: cluster2,
+		api.TagMCMRole:        role,
+	}
+)
+
+func TestOldTags(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tags, errs := NewRelevantTags(oldSpecTags)
+	g.Expect(errs).To(gomega.BeNil())
+
+	g.Expect(tags.Matches(oldSpecTags)).To(gomega.Equal(true))
+	g.Expect(tags.Matches(oldSpecTags2)).To(gomega.Equal(false))
+	g.Expect(tags.Matches(newSpecTags)).To(gomega.Equal(true))
+	g.Expect(tags.Matches(newSpecTags2)).To(gomega.Equal(false))
+}
+
+func TestNewTags(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tags, errs := NewRelevantTags(newSpecTags)
+	g.Expect(errs).To(gomega.BeNil())
+
+	g.Expect(tags.Matches(oldSpecTags)).To(gomega.Equal(true))
+	g.Expect(tags.Matches(oldSpecTags2)).To(gomega.Equal(false))
+	g.Expect(tags.Matches(newSpecTags)).To(gomega.Equal(true))
+	g.Expect(tags.Matches(newSpecTags2)).To(gomega.Equal(false))
+}
+
+func TestEmptyTags(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tags, errs := NewRelevantTags(map[string]string{})
+	g.Expect(tags).To(gomega.BeNil())
+	g.Expect(len(errs)).To(gomega.Equal(2))
+}

--- a/pkg/vsphere/apis/validation/validation.go
+++ b/pkg/vsphere/apis/validation/validation.go
@@ -18,9 +18,10 @@ package validation
 
 import (
 	"fmt"
-	"strings"
 
 	api "github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis"
+	"github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis/tags"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -42,30 +43,8 @@ func ValidateVsphereProviderSpec(spec *api.VsphereProviderSpec, secrets *corev1.
 	}
 
 	allErrs = append(allErrs, validateSecrets(secrets)...)
-	allErrs = append(allErrs, validateSpecTags(spec.Tags)...)
-
-	return allErrs
-}
-
-func validateSpecTags(tags map[string]string) []error {
-	var allErrs []error
-	clusterName := ""
-	nodeRole := ""
-
-	for key := range tags {
-		if strings.Contains(key, "kubernetes.io/cluster/") {
-			clusterName = key
-		} else if strings.Contains(key, "kubernetes.io/role/") {
-			nodeRole = key
-		}
-	}
-
-	if clusterName == "" {
-		allErrs = append(allErrs, fmt.Errorf("tag required of the form kubernetes.io/cluster/****"))
-	}
-	if nodeRole == "" {
-		allErrs = append(allErrs, fmt.Errorf("tag required of the form kubernetes.io/role/****"))
-	}
+	_, tagErrs := tags.NewRelevantTags(spec.Tags)
+	allErrs = append(allErrs, tagErrs...)
 
 	return allErrs
 }

--- a/pkg/vsphere/internal/plugin_spi_impl.go
+++ b/pkg/vsphere/internal/plugin_spi_impl.go
@@ -23,12 +23,14 @@ import (
 	"net/url"
 	"strings"
 
-	api "github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
+
+	api "github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis"
+	"github.com/gardener/machine-controller-manager-provider-vsphere/pkg/vsphere/apis/tags"
 )
 
 // PluginSPIImpl is the real implementation of PluginSPI interface
@@ -141,33 +143,19 @@ func (spi *PluginSPIImpl) ListMachines(ctx context.Context, providerSpec *api.Vs
 
 	machineList := map[string]string{}
 
-	clusterName := ""
-	nodeRole := ""
-	for key := range providerSpec.Tags {
-		if strings.HasPrefix(key, "kubernetes.io/cluster/") {
-			clusterName = key
-		} else if strings.HasPrefix(key, "kubernetes.io/role/") {
-			nodeRole = key
-		}
-	}
-
-	if clusterName == "" || nodeRole == "" {
+	relevantTags, _ := tags.NewRelevantTags(providerSpec.Tags)
+	if relevantTags == nil {
 		return machineList, nil
 	}
 
 	visitor := func(vm *object.VirtualMachine, obj mo.ManagedEntity, field object.CustomFieldDefList) error {
-		matchedCluster := false
-		matchedRole := false
+		customValues := map[string]string{}
 		for _, cv := range obj.CustomValue {
 			sv := cv.(*types.CustomFieldStringValue)
-			switch field.ByKey(sv.Key).Name {
-			case clusterName:
-				matchedCluster = true
-			case nodeRole:
-				matchedRole = true
-			}
+			customValues[field.ByKey(sv.Key).Name] = sv.Value
 		}
-		if matchedCluster && matchedRole {
+
+		if relevantTags.Matches(customValues) {
 			uuid := vm.UUID(ctx)
 			providerID := spi.encodeProviderID(providerSpec.Region, uuid)
 			machineList[providerID] = obj.Name


### PR DESCRIPTION
**What this PR does / why we need it**:
The old tags "kubernetes.io/cluster/xxx" and "kubernetes.io/role/xxx" scheme uses new tag keys for every cluster and role. This causes the creation of new custom attributes for every cluster in vSphere. Besides the tag names are misleading, they have no direct connection to Kubernetes. They are only used for tagged the VM objects.
With the new tagging scheme ("mcm.gardener.cloud/cluster" and "mcm.gardener.cloud/role"), the tag keys are stable and more understandable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
new tagging scheme "mcm.gardener.cloud/cluster" and "mcm.gardener.cloud/role" for VM objects in vSphere
```